### PR TITLE
ツアーページに統計を追加・ログを追加するための関数を追加

### DIFF
--- a/src/atoms/interfaces/tour.ts
+++ b/src/atoms/interfaces/tour.ts
@@ -1,6 +1,17 @@
 import { v4 as uuidV4 } from 'uuid'
 import { ChromeStorageObject } from '../../utils/base/chromeStorage'
 
+export enum LogType {
+  START = 'START',
+  STOP = 'STOP',
+}
+
+export interface Log {
+  type: LogType
+  url: string
+  date: number
+}
+
 export class Tour extends ChromeStorageObject {
   constructor(
     name: string,
@@ -15,6 +26,7 @@ export class Tour extends ChromeStorageObject {
     this.urls = urls
     this.scrollSpeed = scrollSpeed
     this.resumeInterval = resumeInterval
+    this.logs = []
   }
 
   key: string
@@ -23,4 +35,5 @@ export class Tour extends ChromeStorageObject {
   urls: string[]
   scrollSpeed: number
   resumeInterval: number
+  logs: Log[]
 }

--- a/src/components/analytics.tsx
+++ b/src/components/analytics.tsx
@@ -3,69 +3,63 @@ import _ from 'lodash'
 import HighchartsReact from 'highcharts-react-official'
 import * as Highcharts from 'highcharts'
 import React from 'react'
+import { Log } from '../atoms/interfaces/tour'
 
-enum LogType {
-  START = 'START',
-  STOP = 'STOP',
+interface Props {
+  logs?: Log[]
 }
 
-interface Log {
-  type: LogType
-  url: string
-  date: number
-}
-
-export const AnalyticsPage: React.FC = () => {
+export const AnalyticsPage: React.FC<Props> = ({ logs = [] }) => {
   // 過去何時間分
   const pastTime = 24
 
   // 挿入する際にはこの形式で追加していけば良い
   // テストログ
-  const logs: Log[] = [
-    // case 2件カウント出来るか
-    {
-      type: LogType.START,
-      url: 'http://localhost:8000',
-      date: dayjs().toDate().getTime(),
-    },
-    {
-      type: LogType.START,
-      url: 'http://localhost:8000',
-      date: dayjs().toDate().getTime(),
-    },
-    // case 時間帯ををずらしても計測できるか
-    {
-      type: LogType.START,
-      url: 'http://localhost:8000',
-      date: dayjs().subtract(1, 'hour').toDate().getTime(),
-    },
-    // case URIをずらしたら別で計測されるか
-    {
-      type: LogType.START,
-      url: 'http://localhost:9000',
-      date: dayjs().toDate().getTime(),
-    },
-    {
-      type: LogType.START,
-      url: 'http://localhost:9000',
-      date: dayjs().toDate().getTime(),
-    },
-    {
-      type: LogType.START,
-      url: 'http://localhost:9000',
-      date: dayjs().toDate().getTime(),
-    },
-    {
-      type: LogType.START,
-      url: 'http://localhost:9000',
-      date: dayjs().toDate().getTime(),
-    },
-    {
-      type: LogType.START,
-      url: 'http://localhost:9000',
-      date: dayjs().toDate().getTime(),
-    },
-  ]
+  // const logs: Log[] = [
+  //   // case 2件カウント出来るか
+  //   {
+  //     type: LogType.START,
+  //     url: 'http://localhost:8000',
+  //     date: dayjs().toDate().getTime(),
+  //   },
+  //   {
+  //     type: LogType.START,
+  //     url: 'http://localhost:8000',
+  //     date: dayjs().toDate().getTime(),
+  //   },
+  //   // case 時間帯ををずらしても計測できるか
+  //   {
+  //     type: LogType.START,
+  //     url: 'http://localhost:8000',
+  //     date: dayjs().subtract(1, 'hour').toDate().getTime(),
+  //   },
+  //   // case URIをずらしたら別で計測されるか
+  //   {
+  //     type: LogType.START,
+  //     url: 'http://localhost:9000',
+  //     date: dayjs().toDate().getTime(),
+  //   },
+  //   {
+  //     type: LogType.START,
+  //     url: 'http://localhost:9000',
+  //     date: dayjs().toDate().getTime(),
+  //   },
+  //   {
+  //     type: LogType.START,
+  //     url: 'http://localhost:9000',
+  //     date: dayjs().toDate().getTime(),
+  //   },
+  //   {
+  //     type: LogType.START,
+  //     url: 'http://localhost:9000',
+  //     date: dayjs().toDate().getTime(),
+  //   },
+  //   {
+  //     type: LogType.START,
+  //     url: 'http://localhost:9000',
+  //     date: dayjs().toDate().getTime(),
+  //   },
+  // ]
 
   // LOG[] を入力 -> URLごとのデータ かつ 過去24時間を1時間ごと
   // に計測したデータに変換する
@@ -180,11 +174,18 @@ export const AnalyticsPage: React.FC = () => {
         format: '{value}',
       },
     },
+    credits: {
+      enabled: false,
+    },
   }
 
-  return (
-    <>
-      <HighchartsReact highcharts={Highcharts} options={options} />
-    </>
-  )
+  if (logs.length == 0) {
+    return (
+      <div className={'flex items-center justify-center h-[400px] bg-gray-100'}>
+        <div className={'font-bold text-gray-400'}>データが存在しません</div>
+      </div>
+    )
+  }
+
+  return <HighchartsReact highcharts={Highcharts} options={options} />
 }

--- a/src/components/analytics.tsx
+++ b/src/components/analytics.tsx
@@ -177,6 +177,18 @@ export const AnalyticsPage: React.FC<Props> = ({ logs = [] }) => {
     credits: {
       enabled: false,
     },
+    colors: [
+      '#D89145',
+      '#C7D845',
+      '#6FD845',
+      '#45D874',
+      '#45D8CC',
+      '#458CD8',
+      '#5645D8',
+      '#AE45D8',
+      '#D845A9',
+      '#D84551',
+    ],
   }
 
   if (logs.length == 0) {

--- a/src/pages/tourPage.tsx
+++ b/src/pages/tourPage.tsx
@@ -12,6 +12,7 @@ import { tourActions } from '../atoms/tourActions'
 import CirclingLinks from '../components/circling-links'
 import { motion } from 'framer-motion'
 import { pageTransition } from '../utils/variants'
+import { AnalyticsPage } from '../components/analytics'
 
 type TourForm = {
   // id: string
@@ -281,7 +282,7 @@ const TourPage: React.VFC = () => {
                   オートスクロール中断回数
                 </div>
                 {/* レポート表示部分 */}
-                <AnalyticsPage />
+                <AnalyticsPage logs={tour?.logs} />
                 {/* ヒートマップ表示ボタン、データ削除ボタン */}
                 <div className={'flex my-5'}>
                   {/* 実装不可 */}

--- a/src/utils/tour.ts
+++ b/src/utils/tour.ts
@@ -2,7 +2,11 @@ import { Log, Tour } from '../atoms/interfaces/tour'
 import { chromeStorageActions } from './base/chromeStorage'
 
 // ログを追加するための処理
-export const addLog = (tourId: string, log: Log, callback?: () => void) => {
+export const addLog = (
+  tourId: string,
+  log: Log,
+  callback?: () => void
+): void => {
   chromeStorageActions.findById<Tour>('tours', tourId, (tour) => {
     const newTour: Tour = { ...tour, logs: [...tour.logs, log] }
 

--- a/src/utils/tour.ts
+++ b/src/utils/tour.ts
@@ -1,0 +1,11 @@
+import { Log, Tour } from '../atoms/interfaces/tour'
+import { chromeStorageActions } from './base/chromeStorage'
+
+// ログを追加するための処理
+export const addLog = (tourId: string, log: Log, callback?: () => void) => {
+  chromeStorageActions.findById<Tour>('tours', tourId, (tour) => {
+    const newTour: Tour = { ...tour, logs: [...tour.logs, log] }
+
+    chromeStorageActions.update<Tour>('tours', tourId, newTour, callback)
+  })
+}


### PR DESCRIPTION
### 主な変更

- ツアーページに統計を表示するようにしました
- `src/utils/tour.ts` にログを追加するための関数を追加しました。

**ログが有の状態 / ログが無しの状態**
<img src="https://user-images.githubusercontent.com/50326556/151281606-54565d9d-4a5a-4a1d-bac7-dea672cb1f57.png" width="360"> <img src="https://user-images.githubusercontent.com/50326556/151281658-e0c118ec-e799-4aa6-8883-977d7f59c982.png" width="360">

