### PR TITLE
全体とツアーページの UI を変更

### DIFF
--- a/src/atoms/tourActions.ts
+++ b/src/atoms/tourActions.ts
@@ -81,43 +81,22 @@ export const tourActions: TourActions = {
   //     })
   //   }),
   useSaveTour: () =>
-    useRecoilCallback(({ set }) => ({ key = 'tours', tour, callback }) => {
+    useRecoilCallback(() => ({ key = 'tours', tour, callback }) => {
       chromeStorageActions.findById<Tour>(key, tour.id, (findTour) => {
-        const reload = () => {
-          chromeStorageActions.getAll<Tour>(key, (tours) => {
-            set(tourState, () => {
-              return {
-                tours: tours,
-              }
-            })
-
-            callback()
-          })
-        }
-
         if (findTour == null) {
           chromeStorageActions.add<Tour>(key, tour, () => {
-            reload()
+            callback()
           })
         } else {
           chromeStorageActions.update<Tour>(key, findTour.id, tour, () => {
-            reload()
+            callback()
           })
         }
       })
     }),
   useDeleteTour: () =>
-    useRecoilCallback(({ set }) => ({ key = 'tours', tourId, callback }) => {
+    useRecoilCallback(() => ({ key = 'tours', tourId, callback }) => {
       chromeStorageActions.remove<Tour>(key, tourId, () => {
-        // TODO: reload と同じ処理
-        chromeStorageActions.getAll<Tour>(key, (tours) =>
-          set(tourState, () => {
-            return {
-              tours: tours,
-            }
-          })
-        )
-
         callback()
       })
     }),

--- a/src/components/sidber.tsx
+++ b/src/components/sidber.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react'
-import { Link, useParams } from 'react-router-dom'
+import { Link, useLocation, useParams } from 'react-router-dom'
 import { useRecoilValue } from 'recoil'
 import { tourActions, tourState } from '../atoms/tourActions'
 
@@ -9,6 +9,8 @@ interface Props {
 
 export const SideBer: React.FC<Props> = ({ visible }) => {
   const { tourId } = useParams()
+
+  const location = useLocation()
   const tours = useRecoilValue(tourState).tours
 
   const reloadTour = tourActions.useReloadTour()
@@ -44,17 +46,27 @@ export const SideBer: React.FC<Props> = ({ visible }) => {
          *選択しているときはtext-mainColor、font-bold
          *他はデフォルト（text-gray-600）
          */}
-        <div className={'px-12 text-sm pt-7 pb-5 border-b-2 text-gray-600'}>
-          <a href="">全体設定</a>
-        </div>
+        <div className={'pt-2'} />
+        <Link to={'/'}>
+          <div
+            className={`${
+              location.pathname == '/'
+                ? ' font-bold bg-subColor'
+                : 'hover:bg-gray-200'
+            }  ml-7 mr-13 px-3 text-sm text-gray-600 mt-3 py-2 rounded-lg`}
+          >
+            全体設定
+          </div>
+        </Link>
+        <div className={'pb-5 border-b-2'} />
         {tours.map((tour) => {
           const isSelected = tour.id == tourId
 
           return (
             <Link key={tour.id} to={`/tours/${tour.id}`}>
               <div
-                className={`${isSelected && ' font-bold bg-subColor'} ${
-                  !isSelected && 'hover:bg-gray-200'
+                className={`${
+                  isSelected ? ' font-bold bg-subColor' : 'hover:bg-gray-200'
                 } ml-7 mr-13 px-3 text-sm text-gray-600 mt-3 mb-5 py-2 rounded-lg`}
               >
                 <a href="">{tour.name}</a>

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -1,17 +1,12 @@
-import React, { useState } from 'react'
+import React from 'react'
 import ReactDOM from 'react-dom'
 import '../static/style.css'
-import { SideBer } from './components/sidber'
-import Input from './components/input'
-import { ToggleButton } from './components/togglebutton'
 import { Routes, Route, Link, HashRouter } from 'react-router-dom'
 import ky from 'ky'
 import TourPage from './pages/tourPage'
 import { RecoilRoot } from 'recoil'
-import InputRange from './components/input-range'
-import CirclingLinks from './components/circling-links'
 import { AnalyticsPage } from './components/analytics'
-import { Button } from './components/button'
+import IndexPage from './pages/indexPage'
 
 export const route = {
   Index: '/',
@@ -27,7 +22,7 @@ const Options = () => {
     <RecoilRoot>
       <HashRouter>
         <Routes>
-          <Route index element={<Index />} />
+          <Route index element={<IndexPage />} />
           <Route path={route.A} element={<TourPage />} />
           <Route path={route.B} element={<PageB />} />
           <Route path={route.Analytics} element={<AnalyticsPage />} />
@@ -36,150 +31,6 @@ const Options = () => {
         </Routes>
       </HashRouter>
     </RecoilRoot>
-  )
-}
-
-const Index = () => {
-  const [visible, setVisible] = useState(true)
-
-  //設定画面のコードはここに書く！
-  return (
-    <>
-      <div className={`flex ${visible ? 'bg-white' : 'backdrop-contrast-50'}`}>
-        <SideBer visible={visible} />
-
-        {/*コンテンツ*/}
-        <div
-          className={`flex-grow overflow-auto ${visible ? '' : 'contrast-50'}`}
-        >
-          {/* 画面サイズが小さくなった時の三本線のアイコン表示 */}
-          <div className="lg:hidden inline-block mr-10 absolute">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              className="h-[75px] w-[75px] bg-mainColor text-white p-4"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-              onClick={() => setVisible(!visible)}
-            >
-              <path
-                fillRule="evenodd"
-                d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 15a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z"
-                clipRule="evenodd"
-              />
-            </svg>
-          </div>
-          {/* 画面サイズが小さくなった時の×のアイコン表示 */}
-          <div className="lg:hidden inline-block absolute top-0 right-0">
-            <img
-              src="/assets/icons/cancel.png"
-              alt="キャンセルボタン"
-              className={`h-[45px] w-[45px] mt-3 mr-7 ${
-                visible ? 'hidden' : 'block'
-              }`}
-              onClick={() => setVisible(true)}
-            />
-          </div>
-          <div
-            className={'w-[615px] h-screen mx-auto pl-16 lg:mx-0 flex-grow'}
-            onClick={() => setVisible(true)}
-          >
-            {/* 全体設定 */}
-            <div className="font-bold text-2xl pt-7 pb-5">全体設定</div>
-            <div className="flex pb-6">
-              <img
-                src="/assets/icons/vector.png"
-                alt="電源ボタン"
-                className={'mr-3'}
-              />
-              <ToggleButton id="vector" />
-            </div>
-
-            {/*
-         スクロールの設定テーブルを作成
-        */}
-            <table
-              className={
-                'border-2 w-full text-base rounded-md space-0 border-separate mb-6 pb-5 shadow-md'
-              }
-            >
-              <div className={'font-bold text-xl m-4'}>スクロール</div>
-              <div className={'m-5 flex'}>
-                <p className="w-1/12 pt-[6px]">速度</p>
-
-                <div className={'mr-2 w-11/12'}>
-                  {/* スクロールバー */}
-                  <InputRange />
-
-                  {/* スクロールバーの値 */}
-                  <div className={'pb-2 flex justify-between items-center'}>
-                    <div>遅い</div>
-                    <div>速い</div>
-                  </div>
-                </div>
-              </div>
-
-              <div
-                className={'py-1 flex justify-between items-center m-5 mb-5'}
-              >
-                <div>再開までの時間</div>
-                <div className="flex mr-[6px]">
-                  <Input
-                    background_color="bg-gray-200"
-                    textAlign="text-right"
-                    w="w-14"
-                  />
-                  <div>秒</div>
-                </div>
-              </div>
-              <div className={'py-1 flex justify-between items-center m-5'}>
-                <div>最下部からスクロールを戻す</div>
-                <ToggleButton id="scroll_back_from_the_bottom" />
-              </div>
-              <div className={'py-1 flex justify-between items-center m-5'}>
-                <div>戻す時にリロードを行う</div>
-                <ToggleButton id="reload_when_reverting" />
-              </div>
-            </table>
-
-            {/*
-            通知・API設定
-            */}
-
-            <table
-              className={
-                'border-2 w-full text-base rounded-md space-0 border-separate mb-6 pb-5 shadow-md'
-              }
-            >
-              <div className={'font-bold text-xl m-5'}>通知・API設定</div>
-              <div className={'py-1 flex justify-between items-center mx-6'}>
-                <div>Slackと連携</div>
-                <ToggleButton id="connect_to_slack" />
-              </div>
-              <div className={'mx-5 mt-2'}>
-                <Input
-                  w="w-full"
-                  placeholder="連携するアカウントのトークンを入力してください"
-                />
-              </div>
-              <div
-                className={'py-1 flex justify-between items-center mx-5 mt-6'}
-              >
-                <div>LINEと連携</div>
-                <ToggleButton id="connect_to_line" />
-              </div>
-              <div className={'mx-5 mt-3'}>
-                <Input
-                  w="w-full"
-                  placeholder="連携するアカウントのトークンを入力してください"
-                />
-              </div>
-            </table>
-            {/* 下にスペース */}
-            <div className={'h-[20px]'} />
-          </div>
-        </div>
-      </div>
-    </>
   )
 }
 

--- a/src/pages/indexPage.tsx
+++ b/src/pages/indexPage.tsx
@@ -1,0 +1,233 @@
+import React, { useEffect, useState } from 'react'
+import { SideBer } from '../components/sidber'
+import { ToggleButton } from '../components/togglebutton'
+import InputRange from '../components/input-range'
+import Input from '../components/input'
+import { tourActions } from '../atoms/tourActions'
+import { Tour } from '../atoms/interfaces/tour'
+import { Controller, useForm } from 'react-hook-form'
+import { pageTransition } from '../utils/variants'
+import { motion } from 'framer-motion'
+
+type TourForm = {
+  // id: string
+  name: string
+  urls: string[]
+  scrollSpeed: number
+  resumeInterval: number
+}
+
+const IndexPage: React.VFC = () => {
+  const [visible, setVisible] = useState(true)
+
+  const [tour, setTour] = useState<Tour | null>(null)
+
+  const findByTourId = tourActions.useFindByTourId()
+  const saveTour = tourActions.useSaveTour()
+
+  const { setValue, control } = useForm<TourForm>({
+    shouldUnregister: false,
+  })
+
+  useEffect(() => {
+    findByTourId({
+      key: 'general',
+      tourId: 'general',
+      callback: (tour) => {
+        setValue('scrollSpeed', tour?.scrollSpeed ?? 0)
+        setValue('resumeInterval', tour?.resumeInterval ?? 0)
+        setTour(tour)
+      },
+    })
+  }, [])
+
+  const onChangeScrollBar = (value: number) => {
+    const newTour: Tour = { ...tour, id: 'general', scrollSpeed: value }
+
+    saveTour({ key: 'general', tour: newTour })
+  }
+
+  const onChangeResumeInterval = (value: number) => {
+    const newTour: Tour = { ...tour, id: 'general', resumeInterval: value }
+
+    saveTour({ key: 'general', tour: newTour })
+  }
+
+  return (
+    <>
+      <div className={`flex ${visible ? 'bg-white' : 'backdrop-contrast-50'}`}>
+        <SideBer visible={visible} />
+
+        {/*コンテンツ*/}
+        <motion.div
+          initial="out"
+          animate="in"
+          exit="out"
+          variants={pageTransition}
+          className={`flex-grow overflow-auto ${visible ? '' : 'contrast-50'}`}
+        >
+          {/* 画面サイズが小さくなった時の三本線のアイコン表示 */}
+          <div className="lg:hidden inline-block mr-10 absolute">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-[75px] w-[75px] bg-mainColor text-white p-4"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              onClick={() => setVisible(!visible)}
+            >
+              <path
+                fillRule="evenodd"
+                d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 15a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </div>
+          {/* 画面サイズが小さくなった時の×のアイコン表示 */}
+          <div className="lg:hidden inline-block absolute top-0 right-0">
+            <img
+              src="/assets/icons/cancel.png"
+              alt="キャンセルボタン"
+              className={`h-[45px] w-[45px] mt-3 mr-7 ${
+                visible ? 'hidden' : 'block'
+              }`}
+              onClick={() => setVisible(true)}
+            />
+          </div>
+          <div
+            className={'w-[615px] h-screen mx-auto pl-16 lg:mx-0 flex-grow'}
+            onClick={() => setVisible(true)}
+          >
+            {/* 全体設定 */}
+            <div className="font-bold text-2xl pt-7 pb-5">全体設定</div>
+            {/*
+         スクロールの設定テーブルを作成
+        */}
+            <table
+              className={
+                'border-2 w-full text-base rounded-md space-0 border-separate mb-6 pb-5 shadow-md'
+              }
+            >
+              <div className={'font-bold text-xl m-4'}>スクロール</div>
+              <div className={'m-5 flex'}>
+                <p className="w-1/12 pt-[6px]">速度</p>
+
+                <div className={'mr-2 w-11/12'}>
+                  {/* スクロールバー */}
+                  <Controller
+                    name={'scrollSpeed'}
+                    control={control}
+                    rules={{
+                      required: true,
+                      validate: (value) => value >= 0,
+                    }}
+                    defaultValue={0}
+                    render={({ field }) => (
+                      <InputRange
+                        {...field}
+                        onChange={(v) => {
+                          const value = Number(v.currentTarget.value)
+
+                          if (value > 0) {
+                            onChangeScrollBar(value)
+                          }
+
+                          field.onChange(v)
+                        }}
+                      />
+                    )}
+                  />
+
+                  {/* スクロールバーの値 */}
+                  <div className={'pb-2 flex justify-between items-center'}>
+                    <div>遅い</div>
+                    <div>速い</div>
+                  </div>
+                </div>
+              </div>
+
+              <div
+                className={'py-1 flex justify-between items-center m-5 mb-5'}
+              >
+                <div>再開までの時間</div>
+                <div className="flex mr-[6px]">
+                  <Controller
+                    name={'resumeInterval'}
+                    control={control}
+                    rules={{
+                      required: true,
+                      validate: (value) => value >= 0,
+                    }}
+                    render={({ field }) => (
+                      <Input
+                        w="w-14"
+                        textAlign="text-right"
+                        {...field}
+                        value={field.value?.toString() ?? ''}
+                        onChange={(v) => {
+                          const value = Number(v.currentTarget.value)
+
+                          if (value > 0) {
+                            onChangeResumeInterval(value)
+                          }
+
+                          field.onChange(v)
+                        }}
+                      />
+                    )}
+                  />
+                  <div>秒</div>
+                </div>
+              </div>
+              <div className={'py-1 flex justify-between items-center m-5'}>
+                <div>最下部からスクロールを戻す</div>
+                <ToggleButton id="scroll_back_from_the_bottom" />
+              </div>
+              <div className={'py-1 flex justify-between items-center m-5'}>
+                <div>戻す時にリロードを行う</div>
+                <ToggleButton id="reload_when_reverting" />
+              </div>
+            </table>
+
+            {/*
+            通知・API設定
+            */}
+
+            <table
+              className={
+                'border-2 w-full text-base rounded-md space-0 border-separate mb-6 pb-5 shadow-md'
+              }
+            >
+              <div className={'font-bold text-xl m-5'}>通知・API設定</div>
+              <div className={'py-1 flex justify-between items-center mx-6'}>
+                <div>Slackと連携</div>
+                <ToggleButton id="connect_to_slack" />
+              </div>
+              <div className={'mx-5 mt-2'}>
+                <Input
+                  w="w-full"
+                  placeholder="連携するアカウントのトークンを入力してください"
+                />
+              </div>
+              <div
+                className={'py-1 flex justify-between items-center mx-5 mt-6'}
+              >
+                <div>LINEと連携</div>
+                <ToggleButton id="connect_to_line" />
+              </div>
+              <div className={'mx-5 mt-3'}>
+                <Input
+                  w="w-full"
+                  placeholder="連携するアカウントのトークンを入力してください"
+                />
+              </div>
+            </table>
+            {/* 下にスペース */}
+            <div className={'h-[20px]'} />
+          </div>
+        </motion.div>
+      </div>
+    </>
+  )
+}
+
+export default IndexPage

--- a/src/pages/indexPage.tsx
+++ b/src/pages/indexPage.tsx
@@ -24,6 +24,7 @@ const IndexPage: React.VFC = () => {
 
   const findByTourId = tourActions.useFindByTourId()
   const saveTour = tourActions.useSaveTour()
+  const reloadTour = tourActions.useReloadTour()
 
   const { setValue, control } = useForm<TourForm>({
     shouldUnregister: false,
@@ -50,7 +51,7 @@ const IndexPage: React.VFC = () => {
   const onChangeResumeInterval = (value: number) => {
     const newTour: Tour = { ...tour, id: 'general', resumeInterval: value }
 
-    saveTour({ key: 'general', tour: newTour })
+    saveTour({ key: 'general', tour: newTour, callback: () => reloadTour() })
   }
 
   return (

--- a/src/pages/tourPage.tsx
+++ b/src/pages/tourPage.tsx
@@ -133,20 +133,22 @@ const TourPage: React.VFC = () => {
             {/* 設定 */}
             <div className="font-bold text-2xl pt-7 pb-5">{title}</div>
 
-            <div
-              className="flex pb-6"
-              onClick={() => {
-                startSavedTour(tourId)
-              }}
-            >
-              <img
-                src="/assets/icons/vector.png"
-                alt="電源ボタン"
-                className={'mr-3'}
-              />
-              {/* toggleボタン */}
-              <ToggleButton id="vector" />
-            </div>
+            {tour != null && (
+              <div
+                className="flex pb-6"
+                onClick={() => {
+                  startSavedTour(tourId)
+                }}
+              >
+                <img
+                  src="/assets/icons/vector.png"
+                  alt="電源ボタン"
+                  className={'mr-3'}
+                />
+                {/* toggleボタン */}
+                <ToggleButton id="vector" />
+              </div>
+            )}
 
             {/*
           保存リストに表示する名前をつける
@@ -255,7 +257,7 @@ const TourPage: React.VFC = () => {
                       clipRule="evenodd"
                     />
                   </svg>
-                  <div>巡回リンク</div>
+                  <div className={'pl-2'}>巡回リンク</div>
                 </div>
               </div>
               <div className={'mx-5 py-1'}>
@@ -280,26 +282,28 @@ const TourPage: React.VFC = () => {
           レポートテーブル
           */}
 
-            <table
-              className={
-                'border-2 w-full rounded-md space-0 border-separate mb-[20px] pb-5 shadow-md'
-              }
-            >
-              <div className={'font-bold text-xl m-4'}>レポート</div>
-              <div className={'mx-5 mt-1'}>
-                <div className={'pb-[4px] text-base'}>
-                  オートスクロール中断回数
+            {tour != null && (
+              <table
+                className={
+                  'border-2 w-full rounded-md space-0 border-separate mb-[20px] pb-5 shadow-md'
+                }
+              >
+                <div className={'font-bold text-xl m-4'}>レポート</div>
+                <div className={'mx-5 mt-1'}>
+                  <div className={'pb-[4px] text-base'}>
+                    オートスクロール中断回数
+                  </div>
+                  {/* レポート表示部分 */}
+                  <AnalyticsPage logs={tour?.logs} />
+                  {/* ヒートマップ表示ボタン、データ削除ボタン */}
+                  <div className={'flex my-5'}>
+                    {/* 実装不可 */}
+                    {/* <Button p="p-2" text="ヒートマップ" /> */}
+                    <Button p="p-2" text="データ削除" />
+                  </div>
                 </div>
-                {/* レポート表示部分 */}
-                <AnalyticsPage logs={tour?.logs} />
-                {/* ヒートマップ表示ボタン、データ削除ボタン */}
-                <div className={'flex my-5'}>
-                  {/* 実装不可 */}
-                  {/* <Button p="p-2" text="ヒートマップ" /> */}
-                  <Button p="p-2" text="データ削除" />
-                </div>
-              </div>
-            </table>
+              </table>
+            )}
 
             {/* 削除ボタン */}
             <div className={'flex flex-row-reverse '}>

--- a/src/pages/tourPage.tsx
+++ b/src/pages/tourPage.tsx
@@ -33,6 +33,7 @@ const TourPage: React.VFC = () => {
 
   const findByTourId = tourActions.useFindByTourId()
   const saveTour = tourActions.useSaveTour()
+  const reloadTour = tourActions.useReloadTour()
   const deleteTour = tourActions.useDeleteTour()
 
   const { handleSubmit, setValue, control } = useForm<TourForm>({
@@ -73,7 +74,10 @@ const TourPage: React.VFC = () => {
 
     saveTour({
       tour: newTour,
-      callback: () => navigate(`/tours/${newTour.id}`),
+      callback: () => {
+        reloadTour()
+        navigate(`/tours/${newTour.id}`)
+      },
     })
   })
 
@@ -81,6 +85,7 @@ const TourPage: React.VFC = () => {
     deleteTour({
       tourId: tourId,
       callback: () => {
+        reloadTour()
         navigate(`/`)
       },
     })

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -10,8 +10,18 @@ import {
   startTour,
   stopTabScroll,
 } from './utils/scrollControl'
+import { RecoilRoot, useRecoilValue } from 'recoil'
+import { tourActions, tourState } from './atoms/tourActions'
 
 const Popup = () => {
+  return (
+    <RecoilRoot>
+      <Body />
+    </RecoilRoot>
+  )
+}
+
+const Body = () => {
   // スクロールのON/OFFステート
   const [scrollEnabled, setScrollState] = useState(false)
   // 最下部からスクロールを戻すか
@@ -20,11 +30,18 @@ const Popup = () => {
   // 戻るときにリロードを行うか
   const [reloadOnBackEnabled, setReloadOnBackState] = useState(false)
 
+  const tours = useRecoilValue(tourState).tours
+  const reloadTour = tourActions.useReloadTour()
+
   // 副作用（レンダリング後に実行される）
   useEffect(() => {
     // Stateを初期化
     getInitialState()
+
+    reloadTour()
   }, [])
+
+  console.log(tours)
 
   const getInitialState = () => {
     // ストレージを確認
@@ -179,7 +196,7 @@ const Popup = () => {
 
       <div className="px-8 py-1">
         <div className={'text-captionColor py-1'}>保存済みリストを実行</div>
-        {/* <select className="border-2 w-full mb-3 after:color-mainColor">
+        <select className="flex justify-between w-full px-2 py-1 text-xs hover:bg-dividerColor rounded-md border-2">
           <option selected className="after:bg-mainColor">
             選択なし
           </option>
@@ -189,27 +206,34 @@ const Popup = () => {
           <option value="2" className="after:bg-mainColor">
             E展
           </option>
-        </select> */}
+          {tours.map((tour) => {
+            return (
+              <option key={tour.id} value="2" className="after:bg-mainColor">
+                {tour.name}
+              </option>
+            )
+          })}
+        </select>
         <div className="">
-          <button
-            className="flex justify-between w-full px-2 py-1 text-xs hover:bg-dividerColor rounded-md border-2"
-            type="button"
-            data-dropdown-toggle="dropdown"
-          >
-            選択しない
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              className="h-4 w-4"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-            >
-              <path
-                fillRule="evenodd"
-                d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
-                clipRule="evenodd"
-              />
-            </svg>
-          </button>
+          {/*<button*/}
+          {/*  className="flex justify-between w-full px-2 py-1 text-xs hover:bg-dividerColor rounded-md border-2"*/}
+          {/*  type="button"*/}
+          {/*  data-dropdown-toggle="dropdown"*/}
+          {/*>*/}
+          {/*  選択しない*/}
+          {/*  <svg*/}
+          {/*    xmlns="http://www.w3.org/2000/svg"*/}
+          {/*    className="h-4 w-4"*/}
+          {/*    viewBox="0 0 20 20"*/}
+          {/*    fill="currentColor"*/}
+          {/*  >*/}
+          {/*    <path*/}
+          {/*      fillRule="evenodd"*/}
+          {/*      d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"*/}
+          {/*      clipRule="evenodd"*/}
+          {/*    />*/}
+          {/*  </svg>*/}
+          {/*</button>*/}
           {/* DropDown Menu */}
 
           <div

--- a/src/utils/base/chromeStorage.ts
+++ b/src/utils/base/chromeStorage.ts
@@ -73,7 +73,7 @@ export const chromeStorageActions: ChromeStorageActions = {
 
       if (index == -1) {
         callback(null)
-        throw new Error(`${key} does not exists.`)
+        return null
       }
 
       callback(chromeObjects[index])


### PR DESCRIPTION
### 主な変更

- 全体設定を別のファイルに分割
- 新規作成の時はツアー開始ボタンと統計を非表示になるようにしました
- スクロールと再開までの時間を取得するようにしました

**UI**

<img width="256" alt="スクリーンショット 2022-01-28 14 15 19" src="https://user-images.githubusercontent.com/50326556/151491329-988b4a2f-1f63-44ad-b2e7-507362afb504.png"> <img width="256" alt="スクリーンショット 2022-01-28 14 15 23" src="https://user-images.githubusercontent.com/50326556/151491337-43905856-87dd-425f-8a65-de5c119705c0.png">

