### PR TITLE
ツアーの未編集時に保存ボタンを有効化しないように機能追加

### DIFF
--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -20,9 +20,11 @@ export const Button: React.FC<Props> = ({
   return (
     <button
       onClick={onClick}
-      className={`${background_color} ${text_color} hover:opacity-90 rounded-md px-7 text-sm ${p} ${
-        bold && 'font-bold'
-      }`}
+      className={`${
+        onClick == null ? 'bg-captionColor' : background_color
+      } ${text_color} ${
+        onClick == null ? 'cursor-not-allowed' : 'hover:opacity-90'
+      } rounded-md px-7 text-sm ${p} ${bold && 'font-bold'}`}
     >
       {text}
     </button>

--- a/src/pages/tourPage.tsx
+++ b/src/pages/tourPage.tsx
@@ -27,6 +27,8 @@ const TourPage: React.VFC = () => {
   const [tour, setTour] = useState<Tour | null>(null)
   const [visible, setVisible] = useState(true)
   const [isLoading, setIsLoading] = useState(false)
+  // TODO: その場しのぎ感のあるコードなのであとで処理をまとめる
+  const [isEditCirclingLinks, setIsEditCirclingLinks] = useState(false)
 
   const navigate = useNavigate()
 
@@ -35,9 +37,12 @@ const TourPage: React.VFC = () => {
   const reloadTour = tourActions.useReloadTour()
   const deleteTour = tourActions.useDeleteTour()
 
-  const { handleSubmit, setValue, control } = useForm<TourForm>({
-    shouldUnregister: false,
-  })
+  const { handleSubmit, setValue, control, formState, reset } =
+    useForm<TourForm>({
+      shouldUnregister: false,
+    })
+
+  const isDirty = formState.isDirty
 
   useEffect(() => {
     setIsLoading(true)
@@ -77,6 +82,10 @@ const TourPage: React.VFC = () => {
   const title = isEditing ? '設定' : '新規作成'
 
   const onSave = handleSubmit((data) => {
+    // フォームの編集状態を解除
+    setIsEditCirclingLinks(false)
+    reset(data)
+
     const newTour =
       tour == null
         ? new Tour(data.name, data.urls, data.scrollSpeed, data.resumeInterval)
@@ -280,7 +289,10 @@ const TourPage: React.VFC = () => {
                   render={({ field }) => {
                     return (
                       <CirclingLinks
-                        setValue={(values) => setValue('urls', values)}
+                        setValue={(values) => {
+                          setIsEditCirclingLinks(true)
+                          setValue('urls', values)
+                        }}
                         {...field}
                       />
                     )
@@ -319,8 +331,10 @@ const TourPage: React.VFC = () => {
               <div className="ml-3">
                 <Button
                   text="保存"
-                  onClick={onSave}
-                  background_color="bg-mainColor"
+                  onClick={
+                    !isEditing || isEditCirclingLinks || isDirty ? onSave : null
+                  }
+                  background_color={'bg-mainColor'}
                   p="p-2"
                 />
               </div>

--- a/src/pages/tourPage.tsx
+++ b/src/pages/tourPage.tsx
@@ -167,10 +167,12 @@ const TourPage: React.VFC = () => {
                 {tour != null && (
                   <Button
                     text="再生"
-                    onClick={() => {
-                      startSavedTour(tourId)
-                    }}
-                    background_color="bg-mainColor"
+                    onClick={
+                      !isEditCirclingLinks && !isDirty
+                        ? () => startSavedTour(tourId)
+                        : null
+                    }
+                    background_color={'bg-mainColor'}
                     p="p-2"
                   />
                 )}

--- a/src/pages/tourPage.tsx
+++ b/src/pages/tourPage.tsx
@@ -2,7 +2,6 @@ import { useNavigate, useParams } from 'react-router-dom'
 import React, { useEffect, useState } from 'react'
 import { Tour } from '../atoms/interfaces/tour'
 import { SideBer } from '../components/sidber'
-import { ToggleButton } from '../components/togglebutton'
 import { Button } from '../components/button'
 import { useForm, Controller } from 'react-hook-form'
 import Input from '../components/input'
@@ -73,9 +72,9 @@ const TourPage: React.VFC = () => {
   }
 
   // ツアーが存在しているかのフラグ
-  const isExistTour = tour != null
+  const isEditing = tour != null
 
-  const title = isExistTour ? '設定' : '新規作成'
+  const title = isEditing ? '設定' : '新規作成'
 
   const onSave = handleSubmit((data) => {
     const newTour =
@@ -316,7 +315,6 @@ const TourPage: React.VFC = () => {
               </div>
             )}
 
-            {/* 削除ボタン */}
             <div className={'flex flex-row-reverse '}>
               <div className="ml-3">
                 <Button


### PR DESCRIPTION
### 主な変更

* ツアーの未編集時に保存ボタンを有効化しないように機能追加
*  再生ボタンを編集中は有効化しないように変更

### SS

**未編集時**

<img src="https://user-images.githubusercontent.com/50326556/155605802-9434e248-b464-429b-aa38-7ae10ceb7f37.png" width="360">

**編集時**

<img src="https://user-images.githubusercontent.com/50326556/155605783-127ff70b-cfd0-4344-8bc9-c6d601ca9f35.png" width="360">

